### PR TITLE
Fix detecting Hanami application

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,5 +6,10 @@ task :dump do
 end
 
 task :test do
-  sh 'bundle exec vim-flavor test'
+  begin
+    FileUtils.mkdir('config') unless File.directory?('config')
+    sh 'bundle exec vim-flavor test'
+  ensure
+    FileUtils.rm_r('config')
+  end
 end

--- a/plugin/vim-open-alternate.vim
+++ b/plugin/vim-open-alternate.vim
@@ -22,15 +22,35 @@ function! s:IsCucumberStepDefinitionFile(file)
 endfunction
 
 function! s:IsRailsControllerModelViewAssetFile(file)
-  return match(a:file, '\<controllers\>') != -1 || match(a:file, '\<models\>') != -1 || match(a:file, '\<views\>') != -1 || match(a:file, '\<assets\>') != -1 || match(a:file, '\<helpers\>') != -1 || match(a:file, '\<mailers\>') != -1
+  let l:is_ruby_file =
+    \ match(a:file, '^\(app\|spec\)\/controllers\/.*\.rb$') != -1 ||
+    \ match(a:file, '^\(app\|spec\)\/models\/.*\.rb$') != -1 ||
+    \ match(a:file, '^\(app\|spec\)\/views\/.*\.rb$') != -1 ||
+    \ match(a:file, '^\(app\|spec\)\/helpers\/.*\.rb$') != -1 ||
+    \ match(a:file, '^\(app\|spec\)\/mailers\/.*\.rb$') != -1
+  let l:is_rails_app =
+    \ filereadable('config/application.rb') &&
+    \ filereadable('config/routes.rb') &&
+    \ isdirectory('app')
+  return is_ruby_file && is_rails_app
 endfunction
 
 function! s:IsHanamiContainerArchitecture(file)
-  return match(a:file, '^spec\/\w\+\/controllers\/') != -1 || match(a:file, '^spec\/\w\+\/views\/') != -1 || match(a:file, '^apps\/\w\+\/controllers\/') != -1 || match(a:file, '^apps\/\w\+\/views\/') != -1
+  let l:is_ruby_file = match(a:file, '^\(apps\|spec\)\/.*\.rb$') != -1
+  let l:is_hanami_container =
+    \ filereadable('config/environment.rb') &&
+    \ isdirectory('apps')
+  return is_ruby_file && is_hanami_container
 endfunction
 
 function! s:IsHanamiAppImplementationFile(file)
-  return match(a:file, '^app\/.*\.rb$') != -1 || match(a:file, '^apps\/.*\.rb$') != -1
+  let l:is_ruby_file = match(a:file, '^\(app\|spec\)\/.*\.rb$') != -1
+  let l:is_hanami_app =
+    \ filereadable('config/application.rb') &&
+    \ filereadable('config/routes.rb') &&
+    \ filereadable("config/environment.rb") &&
+    \ isdirectory('app')
+  return is_ruby_file && is_hanami_app
 endfunction
 
 function! s:IsJavascriptSpecFile(file)
@@ -67,10 +87,12 @@ function! s:AlternateFileForRSpecFile(rspec_file)
   let alternate_file = substitute(a:rspec_file, 'erb_spec\.rb$', 'erb', '')
   let alternate_file = substitute(alternate_file, '_spec\.rb$', '.rb', '')
   let alternate_file = substitute(alternate_file, '^spec/', '', '')
-  if s:IsHanamiContainerArchitecture(a:rspec_file)
-    let alternate_file = 'apps/' . alternate_file
-  elseif s:IsRailsControllerModelViewAssetFile(alternate_file)
+  if s:IsHanamiAppImplementationFile(a:rspec_file)
     let alternate_file = 'app/' . alternate_file
+  elseif s:IsRailsControllerModelViewAssetFile(a:rspec_file)
+    let alternate_file = 'app/' . alternate_file
+  elseif s:IsHanamiContainerArchitecture(a:rspec_file)
+    let alternate_file = 'apps/' . alternate_file
   else
     let alternate_file = 'lib/' . alternate_file
   end
@@ -120,12 +142,11 @@ endfunction
 function! s:AlternateFileForRubyImplementationFile(ruby_implementation_file)
   let alternate_file = a:ruby_implementation_file
   " go to spec file
-  if s:IsHanamiContainerArchitecture(a:ruby_implementation_file)
-    let alternate_file = substitute(alternate_file, '^apps/', '', '')
+  if s:IsHanamiAppImplementationFile(a:ruby_implementation_file)
+    let alternate_file = substitute(alternate_file, '^app/', '', '')
   elseif s:IsRailsControllerModelViewAssetFile(a:ruby_implementation_file)
     let alternate_file = substitute(alternate_file, '^app/', '', '')
-  elseif s:IsHanamiAppImplementationFile(a:ruby_implementation_file)
-    let alternate_file = substitute(alternate_file, '^app/', '', '')
+  elseif s:IsHanamiContainerArchitecture(a:ruby_implementation_file)
     let alternate_file = substitute(alternate_file, '^apps/', '', '')
   else
     let alternate_file = substitute(alternate_file, '^lib/', '', '')

--- a/plugin/vim-open-alternate.vim
+++ b/plugin/vim-open-alternate.vim
@@ -27,7 +27,8 @@ function! s:IsRailsControllerModelViewAssetFile(file)
     \ match(a:file, '^\(app\|spec\)\/models\/.*\.rb$') != -1 ||
     \ match(a:file, '^\(app\|spec\)\/views\/.*\.rb$') != -1 ||
     \ match(a:file, '^\(app\|spec\)\/helpers\/.*\.rb$') != -1 ||
-    \ match(a:file, '^\(app\|spec\)\/mailers\/.*\.rb$') != -1
+    \ match(a:file, '^\(app\|spec\)\/mailers\/.*\.rb$') != -1 ||
+    \ match(a:file, '^lib\/.*\.rb$') != -1
   let l:is_rails_app =
     \ filereadable('config/application.rb') &&
     \ filereadable('config/routes.rb') &&
@@ -36,7 +37,7 @@ function! s:IsRailsControllerModelViewAssetFile(file)
 endfunction
 
 function! s:IsHanamiContainerArchitecture(file)
-  let l:is_ruby_file = match(a:file, '^\(apps\|spec\)\/.*\.rb$') != -1
+  let l:is_ruby_file = match(a:file, '^\(apps\|lib\|spec\)\/.*\.rb$') != -1
   let l:is_hanami_container =
     \ filereadable('config/environment.rb') &&
     \ isdirectory('apps')
@@ -44,13 +45,19 @@ function! s:IsHanamiContainerArchitecture(file)
 endfunction
 
 function! s:IsHanamiAppImplementationFile(file)
-  let l:is_ruby_file = match(a:file, '^\(app\|spec\)\/.*\.rb$') != -1
+  let l:is_ruby_file = match(a:file, '^\(app\|lib\|spec\)\/.*\.rb$') != -1
   let l:is_hanami_app =
     \ filereadable('config/application.rb') &&
     \ filereadable('config/routes.rb') &&
     \ filereadable("config/environment.rb") &&
     \ isdirectory('app')
   return is_ruby_file && is_hanami_app
+endfunction
+
+function! s:IsRubyGem(file)
+  let l:is_ruby_file = match(a:file, '^\(lib\|spec\)\/.*\.rb$') != -1
+  let l:is_ruby_gem = match(glob('*\.gemspec'), '.*\.gemspec$') != -1
+  return is_ruby_file && is_ruby_gem
 endfunction
 
 function! s:IsJavascriptSpecFile(file)
@@ -93,7 +100,7 @@ function! s:AlternateFileForRSpecFile(rspec_file)
     let alternate_file = 'app/' . alternate_file
   elseif s:IsHanamiContainerArchitecture(a:rspec_file)
     let alternate_file = 'apps/' . alternate_file
-  else
+  elseif s:IsRubyGem(a:rspec_file)
     let alternate_file = 'lib/' . alternate_file
   end
   return alternate_file
@@ -144,11 +151,14 @@ function! s:AlternateFileForRubyImplementationFile(ruby_implementation_file)
   " go to spec file
   if s:IsHanamiAppImplementationFile(a:ruby_implementation_file)
     let alternate_file = substitute(alternate_file, '^app/', '', '')
+    let alternate_file = substitute(alternate_file, '^lib/', '', '')
   elseif s:IsRailsControllerModelViewAssetFile(a:ruby_implementation_file)
     let alternate_file = substitute(alternate_file, '^app/', '', '')
+    let alternate_file = substitute(alternate_file, '^lib/', '', '')
   elseif s:IsHanamiContainerArchitecture(a:ruby_implementation_file)
     let alternate_file = substitute(alternate_file, '^apps/', '', '')
-  else
+    let alternate_file = substitute(alternate_file, '^lib/', '', '')
+  elseif s:IsRubyGem(a:ruby_implementation_file)
     let alternate_file = substitute(alternate_file, '^lib/', '', '')
   end
   let alternate_file = substitute(alternate_file, '\.rb$', '_spec.rb', '')

--- a/t/alternate_file_for.vim
+++ b/t/alternate_file_for.vim
@@ -236,12 +236,6 @@ describe 's:AlternateFileFor'
       end
     end
 
-    context 'when path is a lib RSpec file'
-      it 'returns the paired lib implementation file'
-        Expect vspec#call('s:AlternateFileFor', 'spec/foo_spec.rb') == 'lib/foo.rb'
-      end
-    end
-
     context 'when path is a lib implementation file'
       it 'returns the paired lib RSpec file'
         Expect vspec#call('s:AlternateFileFor', 'lib/foo.rb') == 'spec/foo_spec.rb'
@@ -262,6 +256,14 @@ describe 's:AlternateFileFor'
   end
 
   context 'Ruby Gem RSpec support'
+    before
+      call writefile([], "some_gem.gemspec", "")
+    end
+
+    after
+      call delete("some_gem.gemspec")
+    end
+
     context 'when path is a lib implementation file'
       it 'returns the paired RSpec file'
         Expect vspec#call('s:AlternateFileFor', 'lib/foo.rb') == 'spec/foo_spec.rb'

--- a/t/alternate_file_for.vim
+++ b/t/alternate_file_for.vim
@@ -56,6 +56,16 @@ describe 's:AlternateFileFor'
   end
 
   context 'Hanami Container RSpec support'
+    before
+      call writefile([], "config/environment.rb", "")
+      call mkdir("apps", "")
+    end
+
+    after
+      call delete("config/environment.rb")
+      call system("rm -r apps")
+    end
+
     context 'when path is a controller RSpec file'
       it 'returns the paired controller implementation file'
         Expect vspec#call('s:AlternateFileFor', 'spec/web/controllers/users/create_spec.rb') == 'apps/web/controllers/users/create.rb'
@@ -80,12 +90,6 @@ describe 's:AlternateFileFor'
       end
     end
 
-    context 'when path is a lib RSpec file'
-      it 'returns the paired lib implementation file'
-        Expect vspec#call('s:AlternateFileFor', 'spec/foo/bar/car/my_lib_spec.rb') == 'lib/foo/bar/car/my_lib.rb'
-      end
-    end
-
     context 'when path is a lib implementation file'
       it 'returns the paired lib RSpec file'
         Expect vspec#call('s:AlternateFileFor', 'lib/foo/bar/car/my_lib.rb') == 'spec/foo/bar/car/my_lib_spec.rb'
@@ -106,6 +110,20 @@ describe 's:AlternateFileFor'
   end
 
   context 'Hanami App RSpec support'
+    before
+      call writefile([], "config/routes.rb", "")
+      call writefile([], "config/application.rb", "")
+      call writefile([], "config/environment.rb", "")
+      call mkdir("app", "")
+    end
+
+    after
+      call delete("config/routes.rb")
+      call delete("config/application.rb")
+      call delete("config/environment.rb")
+      call system("rm -r app")
+    end
+
     context 'when path is a controller RSpec file'
       it 'returns the paired controller implementation file'
         Expect vspec#call('s:AlternateFileFor', 'spec/controllers/users/create_spec.rb') == 'app/controllers/users/create.rb'
@@ -130,12 +148,6 @@ describe 's:AlternateFileFor'
       end
     end
 
-    context 'when path is a lib RSpec file'
-      it 'returns the paired lib implementation file'
-        Expect vspec#call('s:AlternateFileFor', 'spec/foo/bar/car/my_lib_spec.rb') == 'lib/foo/bar/car/my_lib.rb'
-      end
-    end
-
     context 'when path is a lib implementation file'
       it 'returns the paired lib RSpec file'
         Expect vspec#call('s:AlternateFileFor', 'lib/foo/bar/car/my_lib.rb') == 'spec/foo/bar/car/my_lib_spec.rb'
@@ -155,7 +167,27 @@ describe 's:AlternateFileFor'
     " end
   end
 
+  context 'Non-Rails and non-Hanami RSpec support'
+    context 'when path is a custom implementation file'
+      it 'returns the paired custom RSpec file'
+        Expect vspec#call('s:AlternateFileFor', 'app/api/v1/user.rb') == 'spec/app/api/v1/user_spec.rb'
+      end
+    end
+  end
+
   context 'Rails RSpec support'
+    before
+      call writefile([], "config/routes.rb", "")
+      call writefile([], "config/application.rb", "")
+      call mkdir("app", "")
+    end
+
+    after
+      call delete("config/routes.rb")
+      call delete("config/application.rb")
+      call system("rm -r app")
+    end
+
     context 'when path is a controller RSpec file'
       it 'returns the paird controller implementation file'
         Expect vspec#call('s:AlternateFileFor', 'spec/controllers/tasks_controller_spec.rb') == 'app/controllers/tasks_controller.rb'
@@ -207,7 +239,6 @@ describe 's:AlternateFileFor'
     context 'when path is a lib RSpec file'
       it 'returns the paired lib implementation file'
         Expect vspec#call('s:AlternateFileFor', 'spec/foo_spec.rb') == 'lib/foo.rb'
-        cd ..
       end
     end
 

--- a/t/is_hanami_application.vim
+++ b/t/is_hanami_application.vim
@@ -1,0 +1,31 @@
+runtime! plugin/vim-open-alternate.vim
+
+call vspec#hint({'scope': 'VimOpenAlternateScope()', 'sid': 'VimOpenAlternateSid()'})
+
+describe 's:IsHanamiAppImplementationFile'
+  before
+    call writefile([], "config/routes.rb", "")
+    call writefile([], "config/application.rb", "")
+    call writefile([], "config/environment.rb", "")
+    call mkdir("app", "")
+  end
+
+  after
+    call delete("config/routes.rb")
+    call delete("config/application.rb")
+    call delete("config/environment.rb")
+    call system("rm -r app")
+  end
+
+  context 'when given a hanami application controller file path'
+    it 'returns true'
+      Expect vspec#call('s:IsHanamiAppImplementationFile', 'app/controllers/application.rb') == 1
+    end
+  end
+
+  context 'when given a hanami application view file path'
+    it 'returns true'
+      Expect vspec#call('s:IsHanamiAppImplementationFile', 'app/views/application_layout.rb') == 1
+    end
+  end
+end

--- a/t/is_hanami_container.vim
+++ b/t/is_hanami_container.vim
@@ -3,6 +3,16 @@ runtime! plugin/vim-open-alternate.vim
 call vspec#hint({'scope': 'VimOpenAlternateScope()', 'sid': 'VimOpenAlternateSid()'})
 
 describe 's:IsHanamiContainerArchitecture'
+  before
+    call writefile([], "config/environment.rb", "")
+    call mkdir("apps", "")
+  end
+
+  after
+    call delete("config/environment.rb")
+    call system("rm -r apps")
+  end
+
   context 'when given an hanami rspec controller file path'
     it 'returns true'
       Expect vspec#call('s:IsHanamiContainerArchitecture', 'spec/web/controllers/users/create_spec.rb') == 1


### PR DESCRIPTION
Hi, 

I have a Sinatra application which contains files like `app/api/v1/user_api.rb`. 
And I also have some spec files, for example `spec/app/api/v1/user_api_spec.rb`. 
However, `OpenAlternate` doesn't work in this case because it thinks that it is a Hanami application.

I was wondering if we could change `IsHanamiAppImplementationFile` to match ruby files only in `app/controllers` and `app/views`?

I've never used Hanami but it seems like it [creates](https://github.com/hanami/hanami/blob/1bf287351e96a639a1061d28a4b38d67d709dd35/lib/hanami/commands/new/app.rb#L73-L74) `app` directory with some pre-existing subdirectories.
Is it common that Hanami application contains files like `app/some_file.rb`?

-----------------

By the way, is there any difference in a file structure between Rails and Hanami applications? Can we also track other files required by these frameworks in the future like:
```
filereadable('config/application.rb') && filereadable('config/routes.rb')
```
to improve detecting whether it is a `rails`/`hanami` or just some other custom ruby applications in `sinatra`, `goliath`, etc.